### PR TITLE
hw2: auth service and task tracker

### DIFF
--- a/auth-service/app/admin.py
+++ b/auth-service/app/admin.py
@@ -1,0 +1,48 @@
+from sqladmin import ModelView
+
+from app.constants import UserEvent
+from app.models import User
+from app.repositories import UserRepository
+from app.schemas import UserSchema
+from app.settings import settings
+from app.use_cases.kafka import SentEventToKafkaUseCase
+from app.utils import get_password_hash
+
+
+class UserAdmin(ModelView, model=User):
+    column_list = [User.id, User.username, User.email, User.is_active]
+    is_async = True
+
+    async def on_model_change(self, data: dict, model: User, is_created: bool) -> None:
+        self._role_was_changed = False
+        if is_created is False and data["role"] != model.role.name:
+            self._role_was_changed = True
+
+        if data["password_hash"] != model.password_hash:
+            data["password_hash"] = get_password_hash(data["password_hash"])
+
+    async def after_model_change(
+        self, data: dict, model: User, is_created: bool
+    ) -> None:
+        """Юзеры могут изменяться как через api, так и через админку.
+        При апдейте из админки также будет отправлять сигналы.
+        """
+        async with self.session_maker(expire_on_commit=False) as session:
+            user = await UserRepository(session).get_by_id(model.id)
+            user_data = UserSchema.model_validate(user)
+
+        await SentEventToKafkaUseCase().execute(
+            settings.USERS_STREAM_NAME,
+            UserEvent.USER_CREATED if is_created else UserEvent.USER_UPDATED,
+            user_data,
+        )
+        if self._role_was_changed:
+            await SentEventToKafkaUseCase().execute(
+                settings.USERS_STREAM_NAME, UserEvent.USER_ROLE_CHANGED, user_data
+            )
+
+    async def after_model_delete(self, model: User) -> None:
+        """Единственный способ удалить пользователя - через админку."""
+        await SentEventToKafkaUseCase().execute(
+            settings.USERS_STREAM_NAME, UserEvent.USER_DELETED, {"id": model.id}
+        )

--- a/auth-service/app/api/token.py
+++ b/auth-service/app/api/token.py
@@ -1,0 +1,29 @@
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
+
+from app.exceptions import UserNotFoundError, WrongPasswordError
+from app.schemas import (
+    TokenSchema,
+)
+from app.use_cases.token import AuthenticateUserUseCase
+
+router = APIRouter()
+
+
+@router.post("/", response_model=TokenSchema)
+async def generate_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    use_case: AuthenticateUserUseCase = Depends(AuthenticateUserUseCase),
+) -> TokenSchema:
+    try:
+        return await use_case.execute(form_data.username, form_data.password)
+    except UserNotFoundError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail="User not found"
+        ) from e
+    except WrongPasswordError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail="Wrong password"
+        ) from e

--- a/auth-service/app/api/users.py
+++ b/auth-service/app/api/users.py
@@ -1,0 +1,53 @@
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.exceptions import UserAlreadyExistsError, UserNotFoundError
+from app.schemas import (
+    CreateUserRequestSchema,
+    UpdateUserRequestSchema,
+    UserSchema,
+)
+from app.use_cases.users import CreateUserUseCase, UpdateUserUseCase, get_current_user
+
+router = APIRouter()
+
+
+@router.post("/", response_model=UserSchema)
+async def create_user(
+    data: CreateUserRequestSchema,
+    use_case: CreateUserUseCase = Depends(CreateUserUseCase),
+) -> UserSchema:
+    try:
+        return await use_case.execute(data)
+    except UserAlreadyExistsError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="User with the same username or email already exists",
+        ) from e
+
+
+@router.get("/me", response_model=UserSchema)
+async def get_user(
+    user: UserSchema = Depends(get_current_user),
+) -> UserSchema:
+    return user.model_dump(mode="json")
+
+
+@router.patch("/me", response_model=UserSchema)
+async def update_user(
+    data: UpdateUserRequestSchema,
+    user: UserSchema = Depends(get_current_user),
+    use_case: UpdateUserUseCase = Depends(UpdateUserUseCase),
+) -> UserSchema:
+    try:
+        return await use_case.execute(user, data)
+    except UserAlreadyExistsError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="User with the same username or email already exists",
+        ) from e
+    except UserNotFoundError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail="User not found"
+        ) from e

--- a/auth-service/app/constants.py
+++ b/auth-service/app/constants.py
@@ -1,0 +1,15 @@
+import enum
+
+
+class Role(str, enum.Enum):
+    ADMIN = "admin"
+    ACCOUNTANT = "accountant"
+    WORKER = "worker"
+    MANAGER = "manager"
+
+
+class UserEvent(str, enum.Enum):
+    USER_CREATED = "UserCreated"
+    USER_UPDATED = "UserUpdated"
+    USER_DELETED = "UserDeleted"
+    USER_ROLE_CHANGED = "UserRoleChanged"

--- a/auth-service/app/exceptions.py
+++ b/auth-service/app/exceptions.py
@@ -1,0 +1,10 @@
+class UserAlreadyExistsError(Exception):
+    pass
+
+
+class UserNotFoundError(Exception):
+    pass
+
+
+class WrongPasswordError(Exception):
+    pass

--- a/auth-service/app/models.py
+++ b/auth-service/app/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import UUID, Boolean, DateTime, Enum, String, Uuid
+from sqlalchemy.orm import Mapped, declarative_base, mapped_column
+
+from app.constants import Role
+from app.utils import verify_password
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True, default=uuid.uuid4)
+    username: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    email: Mapped[str] = mapped_column(String(250), unique=True, nullable=False)
+    role: Mapped[Role] = mapped_column(Enum(Role), default=Role.WORKER)
+    is_active: Mapped[bool] = mapped_column(Boolean(), default=True)
+
+    password_hash: Mapped[str] = mapped_column(String(500))
+    created_at: Mapped[datetime] = mapped_column(DateTime(), default=datetime.now)
+    modified_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(), onupdate=datetime.now
+    )
+
+    def verify_password(self, password: str) -> bool:
+        return verify_password(password, self.password_hash)

--- a/auth-service/app/repositories.py
+++ b/auth-service/app/repositories.py
@@ -1,0 +1,66 @@
+from uuid import UUID
+
+from asyncpg import UniqueViolationError
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.constants import Role
+from app.exceptions import UserAlreadyExistsError
+from app.models import User
+from app.schemas import UpdateUserRequestSchema
+from app.utils import get_password_hash
+
+
+class UserRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_id(self, user_id: UUID) -> User:
+        stmt = select(User).where(User.id == user_id)
+        return await self.session.scalar(stmt)
+
+    async def get_by_username(self, username: str) -> User:
+        stmt = select(User).where(User.username == username)
+        return await self.session.scalar(stmt)
+
+    async def create(
+        self, username: str, email: str, password: str, role=Role.WORKER
+    ) -> User:
+        password_hash = get_password_hash(password)
+
+        user = User(
+            username=username,
+            email=email,
+            role=role,
+            password_hash=password_hash,
+        )
+        self.session.add(user)
+
+        try:
+            await self.session.flush()
+        except IntegrityError as e:
+            if e.orig.pgcode == UniqueViolationError.sqlstate:
+                raise UserAlreadyExistsError() from e
+            else:
+                raise e
+
+        return user
+
+    async def update(self, user: User, data: UpdateUserRequestSchema):
+        if data.password:
+            data.password = get_password_hash(data.password)
+
+        for key, value in data.model_dump(exclude_unset=True).items():
+            setattr(user, key, value)
+
+        self.session.add(user)
+        try:
+            await self.session.flush()
+        except IntegrityError as e:
+            if e.orig.pgcode == UniqueViolationError.sqlstate:
+                raise UserAlreadyExistsError() from e
+            else:
+                raise e
+
+        return user

--- a/auth-service/app/schemas.py
+++ b/auth-service/app/schemas.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr
+
+from app.constants import Role
+
+
+class TokenSchema(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class UserSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID | None
+    username: str
+    email: str
+    role: Role
+    is_active: bool
+    created_at: datetime
+    modified_at: datetime | None
+
+
+class CreateUserRequestSchema(BaseModel):
+    username: str
+    email: EmailStr
+    password: str
+
+
+class UpdateUserRequestSchema(BaseModel):
+    username: str | None = None
+    email: EmailStr | None = None
+    password: str | None = None

--- a/auth-service/app/use_cases/token.py
+++ b/auth-service/app/use_cases/token.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta
+
+from jose import jwt
+
+from app.exceptions import UserNotFoundError, WrongPasswordError
+from app.repositories import UserRepository
+from app.schemas import TokenSchema, UserSchema
+from app.settings import settings
+from app.use_cases._base import BaseSessionUseCase
+
+
+class AuthenticateUserUseCase(BaseSessionUseCase):
+    async def execute(self, username: str, password: str) -> TokenSchema:
+        user = await UserRepository(self.session).get_by_username(username)
+        if not user:
+            raise UserNotFoundError()
+
+        if not user.verify_password(password):
+            raise WrongPasswordError()
+
+        user_obj = UserSchema.model_validate(user)
+        claims = user_obj.model_dump(mode="json")
+        claims["expire"] = datetime.utcnow() + timedelta(
+            minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
+        )
+
+        token = jwt.encode(user_obj.model_dump(mode="json"), settings.SECRET_KEY)
+        return TokenSchema(access_token=token, token_type="bearer")

--- a/auth-service/app/use_cases/users.py
+++ b/auth-service/app/use_cases/users.py
@@ -1,0 +1,65 @@
+from http import HTTPStatus
+
+from fastapi import Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.constants import UserEvent
+from app.db import get_session
+from app.exceptions import UserNotFoundError
+from app.repositories import UserRepository
+from app.schemas import (
+    CreateUserRequestSchema,
+    UpdateUserRequestSchema,
+    UserSchema,
+)
+from app.settings import settings
+from app.use_cases._base import BaseSessionUseCase
+from app.use_cases.kafka import SentEventToKafkaUseCase
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+async def get_current_user(
+    session: AsyncSession = Depends(get_session), token: str = Depends(oauth2_scheme)
+) -> UserSchema:
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+        user = await UserRepository(session).get_by_id(payload.get("id"))
+        if not user:
+            raise UserNotFoundError("User not found")
+        return UserSchema.model_validate(user)
+    except Exception as e:
+        raise HTTPException(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            detail=str(e),
+        ) from e
+
+
+class CreateUserUseCase(BaseSessionUseCase):
+    async def execute(self, data: CreateUserRequestSchema) -> UserSchema:
+        user = await UserRepository(self.session).create(
+            username=data.username, password=data.password, email=data.email
+        )
+        user_data = UserSchema.model_validate(user)
+        await SentEventToKafkaUseCase().execute(
+            settings.USERS_STREAM_NAME, UserEvent.USER_CREATED, user_data
+        )
+        return user_data
+
+
+class UpdateUserUseCase(BaseSessionUseCase):
+    async def execute(
+        self, user_data: UserSchema, data: UpdateUserRequestSchema
+    ) -> UserSchema:
+        user = await UserRepository(self.session).get_by_id(user_data.id)
+        if not user:
+            raise UserNotFoundError()
+
+        user = await UserRepository(self.session).update(user, data)
+        user_data = UserSchema.model_validate(user)
+        await SentEventToKafkaUseCase().execute(
+            settings.USERS_STREAM_NAME, UserEvent.USER_UPDATED, user_data
+        )
+        return user_data

--- a/task-tracker/app/admin.py
+++ b/task-tracker/app/admin.py
@@ -1,0 +1,12 @@
+from sqladmin import ModelView
+
+from app.models import User
+
+
+class UserAdmin(ModelView, model=User):
+    column_list = [User.id, User.username, User.email, User.is_active]
+    is_async = True
+
+    can_create = False
+    can_edit = False
+    can_delete = False

--- a/task-tracker/app/api/tasks.py
+++ b/task-tracker/app/api/tasks.py
@@ -1,0 +1,100 @@
+from http import HTTPStatus
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.constants import Role
+from app.exceptions import (
+    OnlyAssignedUserCanCompleteTaskError,
+    TaskNotFoundError,
+    UserNotFoundError,
+)
+from app.schemas import CreateTaskRequestSchema, TaskSchema, UserSchema
+from app.use_cases.tasks import (
+    CompleteTaskUseCase,
+    CreateTaskUseCase,
+    GetTasksUseCase,
+    GetTaskUseCase,
+    ShuffleTasksUseCase,
+)
+from app.use_cases.users import get_current_user
+
+router = APIRouter()
+
+
+@router.post("/", response_model=TaskSchema)
+async def create_task(
+    data: CreateTaskRequestSchema,
+    user: UserSchema = Depends(get_current_user),
+    use_case: CreateTaskUseCase = Depends(CreateTaskUseCase),
+) -> TaskSchema:
+    try:
+        return await use_case.execute(data)
+    except UserNotFoundError:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail="Task executor not found",
+        )
+
+
+@router.get("/", response_model=list[TaskSchema])
+async def get_tasks(
+    user: UserSchema = Depends(get_current_user),
+    use_case: GetTasksUseCase = Depends(GetTasksUseCase),
+) -> list[TaskSchema]:
+    return await use_case.execute(user)
+
+
+@router.get("/{task_id}", response_model=TaskSchema)
+async def get_task(
+    task_id: UUID,
+    user: UserSchema = Depends(get_current_user),
+    use_case: GetTaskUseCase = Depends(GetTaskUseCase),
+) -> TaskSchema:
+    try:
+        return await use_case.execute(task_id, user)
+    except TaskNotFoundError:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail="Task not found",
+        )
+
+
+@router.post("/{task_id}/complete", response_model=TaskSchema)
+async def complete_task(
+    task_id: UUID,
+    user: UserSchema = Depends(get_current_user),
+    use_case: CompleteTaskUseCase = Depends(CompleteTaskUseCase),
+) -> TaskSchema:
+    try:
+        return await use_case.execute(task_id, user)
+    except TaskNotFoundError:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail="Task not found",
+        )
+    except OnlyAssignedUserCanCompleteTaskError:
+        if user.role in (Role.ADMIN, Role.MANAGER):
+            raise HTTPException(
+                status_code=HTTPStatus.FORBIDDEN,
+                detail="Only the assigned user can complete the task",
+            )
+        else:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                detail="Task not found",
+            )
+
+
+@router.post("/shuffle", response_model=list[TaskSchema])
+async def shuffle_tasks(
+    user: UserSchema = Depends(get_current_user),
+    use_case: ShuffleTasksUseCase = Depends(ShuffleTasksUseCase),
+) -> list[TaskSchema]:
+    if user.role not in (Role.ADMIN, Role.MANAGER):
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN,
+            detail="Only managers and administrators can shuffle tasks",
+        )
+
+    return await use_case.execute()

--- a/task-tracker/app/constants.py
+++ b/task-tracker/app/constants.py
@@ -1,0 +1,22 @@
+import enum
+
+
+class Role(enum.Enum):
+    ADMIN = "admin"
+    ACCOUNTANT = "accountant"
+    WORKER = "worker"
+    MANAGER = "manager"
+
+
+class UserEvent(str, enum.Enum):
+    USER_CREATED = "UserCreated"
+    USER_UPDATED = "UserUpdated"
+    USER_DELETED = "UserDeleted"
+    USER_ROLE_CHANGED = "UserRoleChanged"
+
+
+class TaskEvent(str, enum.Enum):
+    TASK_CREATED = "TaskCreated"
+    TASK_UPDATED = "TaskUpdated"
+    TASK_ASSIGNED = "TaskAssigned"
+    TASK_COMPLETED = "TaskCompleted"

--- a/task-tracker/app/consumers.py
+++ b/task-tracker/app/consumers.py
@@ -1,0 +1,65 @@
+import asyncio
+import json
+from logging import getLogger
+
+import aiokafka
+
+from app.constants import UserEvent
+from app.db import async_session
+from app.settings import settings
+from app.use_cases.users import (
+    CreateUserUseCase,
+    DeleteUserUseCase,
+    UpdateUserUseCase,
+    UserRoleChangedUseCase,
+)
+
+logger = getLogger(__name__)
+
+EVENT_HANDLERS = {
+    UserEvent.USER_CREATED.value: CreateUserUseCase,
+    UserEvent.USER_UPDATED.value: UpdateUserUseCase,
+    UserEvent.USER_DELETED.value: DeleteUserUseCase,
+    UserEvent.USER_ROLE_CHANGED.value: UserRoleChangedUseCase,
+}
+
+
+async def handle_message(msg):
+    logger.info(f"Received new message from topic {msg.topic}: {msg}")
+
+    if msg.topic == settings.USERS_STREAM_NAME:
+        json_data = json.loads(msg.value)
+        event_name = json_data.get("event_name")
+        if event_name in EVENT_HANDLERS:
+            async with async_session.begin() as session:
+                handler = EVENT_HANDLERS[event_name](session=session)
+                await handler.execute(json_data.get("data"))
+        else:
+            logger.info(f"Got unsupported event: {event_name}")
+
+
+async def consume():
+    consumer = aiokafka.AIOKafkaConsumer(
+        settings.USERS_STREAM_NAME,
+        bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVER,
+        group_id=settings.KAFKA_GROUP_ID,
+    )
+    await consumer.start()
+    try:
+        async for msg in consumer:
+            try:
+                await handle_message(msg)
+            except Exception as e:
+                logger.exception(f"raised unhandled error: {e}")
+
+    finally:
+        await consumer.stop()
+
+
+def main():
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(consume())
+
+
+if __name__ == "__main__":
+    main()

--- a/task-tracker/app/exceptions.py
+++ b/task-tracker/app/exceptions.py
@@ -1,0 +1,10 @@
+class UserNotFoundError(Exception):
+    pass
+
+
+class TaskNotFoundError(Exception):
+    pass
+
+
+class OnlyAssignedUserCanCompleteTaskError(Exception):
+    pass

--- a/task-tracker/app/models.py
+++ b/task-tracker/app/models.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import UUID, Boolean, DateTime, Enum, ForeignKey, String, Uuid
+from sqlalchemy.orm import Mapped, declarative_base, mapped_column, relationship
+
+from app.constants import Role
+from app.utils import verify_password
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True, default=uuid.uuid4)
+    username: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    email: Mapped[str] = mapped_column(String(250), unique=True, nullable=False)
+    role: Mapped[Role] = mapped_column(Enum(Role), default=Role.WORKER)
+    is_active: Mapped[bool] = mapped_column(Boolean(), default=True)
+    assigned_tasks: Mapped[list["Task"]] = relationship(back_populates="assigned_to")
+
+    def verify_password(self, password: str) -> bool:
+        return verify_password(password, self.password_hash)
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True, default=uuid.uuid4)
+    assigned_to_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+    assigned_to: Mapped["User"] = relationship(back_populates="assigned_tasks")
+    title: Mapped[str]
+    description: Mapped[str] = mapped_column(default=True)
+    completed: Mapped[bool] = mapped_column(default=False)
+    cost: Mapped[Decimal]
+    remuneration: Mapped[Decimal]
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(), default=datetime.now)
+    modified_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(), onupdate=datetime.now
+    )
+
+    def verify_password(self, password: str) -> bool:
+        return verify_password(password, self.password_hash)

--- a/task-tracker/app/repositories.py
+++ b/task-tracker/app/repositories.py
@@ -1,0 +1,104 @@
+from decimal import Decimal
+from typing import Any, Iterable
+from uuid import UUID
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.constants import Role
+from app.models import Task, User
+from app.schemas import UserSchema
+
+
+class UserRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_id(self, user_id: UUID) -> User:
+        stmt = select(User).where(User.id == user_id)
+        return await self.session.scalar(stmt)
+
+    async def get_random(self) -> User:
+        stmt = select(User).where(User.role.not_in([Role.ADMIN, Role.MANAGER]))
+        return await self.session.scalar(stmt.order_by(func.random()))
+
+    async def create(self, user_data: UserSchema) -> User:
+        user = User(
+            id=user_data.id,
+            username=user_data.username,
+            email=user_data.email,
+            role=user_data.role,
+            is_active=user_data.is_active,
+        )
+        self.session.add(user)
+        await self.session.flush()
+
+        return user
+
+    async def update(self, user: User, user_data: UserSchema) -> User:
+        for key, value in user_data.model_dump().items():
+            setattr(user, key, value)
+
+        self.session.add(user)
+        await self.session.flush()
+        return user
+
+    async def delete(self, user_id: UUID):
+        stmt = delete(User).where(User.id == user_id)
+        return await self.session.scalar(stmt)
+
+
+class TaskRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_id(self, task_id: UUID) -> Task:
+        stmt = (
+            select(Task).options(joinedload(Task.assigned_to)).where(Task.id == task_id)
+        )
+        return await self.session.scalar(stmt)
+
+    async def get_all(
+        self,
+        user_id: UUID | None = None,
+        completed: bool | None = None,
+    ) -> Iterable[Task]:
+        stmt = select(Task).options(joinedload(Task.assigned_to))
+
+        if user_id:
+            stmt = stmt.where(assigned_to=user_id)
+
+        if completed is not None:
+            stmt = stmt.where(completed=completed)
+
+        result = await self.session.execute(stmt.order_by(Task.created_at.desc()))
+        return result.scalars().all()
+
+    async def create(
+        self,
+        title: str,
+        description: str,
+        cost: Decimal,
+        remuneration: Decimal,
+        assigned_to: User,
+    ) -> Task:
+        task = Task(
+            title=title,
+            description=description,
+            cost=cost,
+            remuneration=remuneration,
+            assigned_to=assigned_to,
+        )
+        self.session.add(task)
+        await self.session.flush()
+
+        return task
+
+    async def update(self, task: Task, **kwargs: Any) -> Task:
+        for key, value in kwargs.items():
+            setattr(task, key, value)
+
+        self.session.add(task)
+        await self.session.flush()
+        return task

--- a/task-tracker/app/schemas.py
+++ b/task-tracker/app/schemas.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, TypeAdapter
+
+from app.constants import Role
+
+
+class TokenSchema(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class UserSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    username: str
+    email: str
+    role: Role
+    is_active: bool
+
+
+class TaskSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID | None
+    assigned_to: UserSchema
+    title: str
+    description: str
+    completed: bool
+    cost: Decimal
+    remuneration: Decimal
+    created_at: datetime
+    modified_at: datetime | None
+
+
+task_list_adapter = TypeAdapter(list[TaskSchema])
+
+
+class CreateTaskRequestSchema(BaseModel):
+    title: str
+    description: str

--- a/task-tracker/app/use_cases/tasks.py
+++ b/task-tracker/app/use_cases/tasks.py
@@ -1,0 +1,134 @@
+from decimal import Decimal
+from random import randint
+from uuid import UUID
+
+from app.constants import Role, TaskEvent
+from app.exceptions import (
+    OnlyAssignedUserCanCompleteTaskError,
+    TaskNotFoundError,
+    UserNotFoundError,
+)
+from app.models import Task, User
+from app.repositories import TaskRepository, UserRepository
+from app.schemas import (
+    CreateTaskRequestSchema,
+    TaskSchema,
+    UserSchema,
+)
+from app.settings import settings
+from app.use_cases._base import BaseSessionUseCase
+from app.use_cases.kafka import SentEventToKafkaUseCase
+
+
+class CreateTaskUseCase(BaseSessionUseCase):
+    async def execute(self, task_data: CreateTaskRequestSchema) -> TaskSchema:
+        task = await TaskRepository(self.session).create(
+            title=task_data.title,
+            description=task_data.description,
+            cost=self._get_cost(),
+            remuneration=self._get_remuneration(),
+            assigned_to=await self._get_user(),
+        )
+
+        task_data = TaskSchema.model_validate(task)
+
+        SentEventToKafkaUseCase().execute(
+            settings.TASKS_STREAM_NAME, TaskEvent.TASK_CREATED, task_data
+        )
+        SentEventToKafkaUseCase().execute(
+            settings.TASKS_STREAM_NAME, TaskEvent.TASK_ASSIGNED, task_data
+        )
+
+        return task_data
+
+    def _get_cost(self) -> Decimal:
+        return Decimal(randint(10, 20))
+
+    def _get_remuneration(self):
+        return Decimal(randint(20, 40))
+
+    async def _get_user(self) -> User:
+        user = await UserRepository(self.session).get_random()
+        if not user:
+            raise UserNotFoundError()
+        return user
+
+
+class CompleteTaskUseCase(BaseSessionUseCase):
+    async def execute(self, task_id: UUID, user: UserSchema) -> TaskSchema:
+        task = await TaskRepository(self.session).get_by_id(task_id)
+        if not task:
+            raise TaskNotFoundError()
+
+        if task.assigned_to_id != user.id:
+            raise OnlyAssignedUserCanCompleteTaskError()
+
+        task = await TaskRepository(self.session).update(task=task, completed=True)
+
+        task_data = TaskSchema.model_validate(task)
+
+        SentEventToKafkaUseCase().execute(
+            settings.TASKS_STREAM_NAME, TaskEvent.TASK_UPDATED, task_data
+        )
+        SentEventToKafkaUseCase().execute(
+            settings.TASKS_STREAM_NAME, TaskEvent.TASK_COMPLETED, task_data
+        )
+        return task_data
+
+
+class ShuffleTasksUseCase(BaseSessionUseCase):
+    async def execute(self, user: UserSchema | None = None) -> list[TaskSchema]:
+        tasks = await TaskRepository(self.session).get_all(
+            completed=False,
+            user_id=user and user.id,
+        )
+
+        tasks_data = []
+
+        for task in tasks:
+            tasks_data.append(await self._reassign_task(task))
+
+        return tasks_data
+
+    async def _get_user(self) -> User:
+        user = await UserRepository(self.session).get_random()
+        if not user:
+            raise UserNotFoundError()
+        return user
+
+    async def _reassign_task(self, task: Task) -> TaskSchema:
+        task = await TaskRepository(self.session).update(
+            task, assigned_to=await self._get_user()
+        )
+
+        task_data = TaskSchema.model_validate(task)
+
+        SentEventToKafkaUseCase().execute(
+            settings.TASKS_STREAM_NAME, TaskEvent.TASK_UPDATED, task_data
+        )
+        SentEventToKafkaUseCase().execute(
+            settings.TASKS_STREAM_NAME, TaskEvent.TASK_ASSIGNED, task_data
+        )
+
+        return task_data
+
+
+class GetTasksUseCase(BaseSessionUseCase):
+    async def execute(self, user: UserSchema) -> list[TaskSchema]:
+        tasks = await TaskRepository(self.session).get_all(
+            user_id=user.id if user.role not in (Role.ADMIN, Role.MANAGER) else None
+        )
+        return [TaskSchema.model_validate(task) for task in tasks]
+
+
+class GetTaskUseCase(BaseSessionUseCase):
+    async def execute(self, task_id: UUID, user: UserSchema) -> TaskSchema:
+        task = await TaskRepository(self.session).get_by_id(task_id)
+        if (
+            not task
+            or user.role not in (Role.ADMIN, Role.MANAGER)
+            and task.assigned_to != user.id
+        ):
+            raise TaskNotFoundError()
+
+        return TaskSchema.model_validate(task)

--- a/task-tracker/app/use_cases/users.py
+++ b/task-tracker/app/use_cases/users.py
@@ -1,0 +1,65 @@
+from http import HTTPStatus
+
+from fastapi import Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.constants import Role
+from app.db import get_session
+from app.exceptions import UserNotFoundError
+from app.repositories import UserRepository
+from app.schemas import (
+    UserSchema,
+)
+from app.settings import settings
+from app.use_cases._base import BaseSessionUseCase
+from app.use_cases.tasks import ShuffleTasksUseCase
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl=settings.TOKEN_URL)
+
+
+async def get_current_user(
+    session: AsyncSession = Depends(get_session), token: str = Depends(oauth2_scheme)
+) -> UserSchema:
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+        user = await UserRepository(session).get_by_id(payload.get("id"))
+        if not user:
+            raise UserNotFoundError("User not found")
+        return UserSchema.model_validate(user)
+    except Exception as e:
+        raise HTTPException(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            detail=str(e),
+        ) from e
+
+
+class CreateUserUseCase(BaseSessionUseCase):
+    async def execute(self, user_event_data: dict) -> None:
+        user_data = UserSchema.model_validate(user_event_data)
+        await UserRepository(self.session).create(user_data)
+
+
+class UpdateUserUseCase(BaseSessionUseCase):
+    async def execute(self, user_event_data: dict) -> None:
+        user_data = UserSchema.model_validate(user_event_data)
+        user = await UserRepository(self.session).get_by_id(user_data.id)
+        if user:
+            await UserRepository(self.session).update(user, user_data)
+        else:
+            await UserRepository(self.session).create(user_data)
+
+
+class DeleteUserUseCase(BaseSessionUseCase):
+    async def execute(self, user_event_data: dict) -> None:
+        await UserRepository(self.session).delete(user_event_data["id"])
+
+
+class UserRoleChangedUseCase(BaseSessionUseCase):
+    async def execute(self, user_event_data: dict) -> None:
+        user_data = UserSchema.model_validate(user_event_data)
+        if user_data not in (Role.ADMIN, Role.MANAGER):
+            return
+
+        await ShuffleTasksUseCase(self.session).execute(user_data)


### PR DESCRIPTION
Мой основной стэк это django/drf +rabbitmq, но делать на них было бы слишком скучно. 
Взял fastapi + async sqlalchemy 2, в этом стэке я плаваю, поэтому будет много глупых ошибок, прости.

Если тебя интересуют только события, то можешь искать строки `SentEventToKafkaUseCase().execute(...)`, она продьюсит сообщения в кафку из use cases.